### PR TITLE
Fixed issue #25.

### DIFF
--- a/R/switch_axis.R
+++ b/R/switch_axis.R
@@ -10,6 +10,7 @@ hinvert_title_grob <- function(grob)
   grob$vp[[1]]$layout$widths[3] <- widths[1]
   # revert the text
   grob$children[[1]]$hjust <- 1 - grob$children[[1]]$hjust # revert hjust
+  grob$children[[1]]$vjust <- 1 - grob$children[[1]]$vjust # revert vjust
   grob$children[[1]]$x <- grid::unit(1, "npc") - grob$children[[1]]$x
   grob
 }
@@ -25,6 +26,7 @@ vinvert_title_grob <- function(grob)
   grob$vp[[1]]$layout$heights[1] <- heights[3]
   grob$vp[[1]]$layout$heights[3] <- heights[1]
   # revert the text
+  grob$children[[1]]$hjust <- 1 - grob$children[[1]]$hjust # revert hjust
   grob$children[[1]]$vjust <- 1 - grob$children[[1]]$vjust # revert vjust
   grob$children[[1]]$y <- grid::unit(1, "npc") - grob$children[[1]]$y
   grob


### PR DESCRIPTION
This fix allows 90 degree angled text to display properly when an axis is switched. Some idiosyncrasies remain, such as hjust and vjust drastically changing behavior from at 90 degrees from 89 or 91 degrees, but that appears to caused outside the cowplot package.