### PR TITLE
Allow custom axes on the drawing layer

### DIFF
--- a/R/draw.R
+++ b/R/draw.R
@@ -219,12 +219,15 @@ draw_grob <- function(grob, x = 0, y = 0, width = 1, height = 1){
 
 #' Set up a drawing layer on top of a ggplot
 #' @param plot The plot to use as a starting point. Can be either a ggplot2 plot or an arbitrary gtable.
+#' @param xlim The x-axis limits for the drawing layer (default is [0,1])
+#' @param ylim The y-axis limits for the drawing layer (default is [0,1])
 #' @export
-ggdraw <- function(plot = NULL){
+ggdraw <- function(plot = NULL, xlim = c(0, 1), ylim = c(0, 1)) {
+  
   d <- data.frame(x=0:1, y=0:1) # dummy data
   p <- ggplot(d, aes_string(x="x", y="y")) + # empty plot
-    scale_x_continuous(limits = c(0, 1), expand = c(0, 0)) +
-    scale_y_continuous(limits = c(0, 1), expand = c(0, 0)) +
+    scale_x_continuous(limits = xlim, expand = c(0, 0)) +
+    scale_y_continuous(limits = ylim, expand = c(0, 0)) +
     theme_nothing() + # with empty theme
     labs(x=NULL, y=NULL) # and absolutely no axes
 


### PR DESCRIPTION
In case a unit square is inconvenient or a user wants a direct mapping to work with (i.e. width/height mapping to width/height of graphics device output).

Example case: You have 3 plots you want to arrange like so:

    1122
    1122
    3333

And you want the 1-block to be square and the 2-block to be square but the 3-block to be half its height (you can achieve the effect correctly by working on a subset of the unit square but there is left over white space).

You can also set the scales to represent your final image and plot directly if you want.

I'm not sure such a change breaks anything, but I've definitely found this adjustment useful.