### PR TITLE
Separate align fxn

### DIFF
--- a/R/plot_grid.R
+++ b/R/plot_grid.R
@@ -1,19 +1,18 @@
 
 #' Align multiple plots vertically and/or horizontally
 #'
-#' Align multipl plots
+#' Align multiple plots for plotting manually. Can be used to graph two separate y axis, but still doesn't work if second y axis needs to be shown.
 #' @param ... List of plots to be aligned.
 #' @param plotlist (optional) List of plots to display. Alternatively, the plots can be provided
 #' individually as the first n arguments of the function plot_grid (see examples).
 #' @param align (optional) Specifies whether graphs in the grid should be horizontally ("h") or
 #'  vertically ("v") aligned. Options are "none" (default), "hv" (align in both directions), "h", and "v".
 #' @examples
-#' p1 <- qplot(1:10, 1:10)
-#' p2 <- qplot(1:10, (1:10)^2)
-#' p3 <- qplot(1:10, (1:10)^3)
-#' p4 <- qplot(1:10, (1:10)^4)
+#' p1 <- qplot(1:10, rpois(10, lambda=15), geom="point")
+#' p2 <- qplot(1:10, (1:10)^2, geom="line") + theme_nothing()
 #' # simple grid
-#' align_plots(p1, p2, p3, p4)
+#' aligned_plots <- align_plots(p1, p2, align="hv")
+#' ggdraw() + draw_grob(aligned_plots[[1]]) + draw_grob(aligned_plots[[2]])
 #' @export
 align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv")){
   plots <- c(list(...), plotlist)
@@ -80,6 +79,7 @@ align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"))
   }
   grobs
 }
+
 
 
 

--- a/R/plot_grid.R
+++ b/R/plot_grid.R
@@ -10,7 +10,7 @@
 #' @examples
 #' p1 <- qplot(1:10, rpois(10, lambda=15), geom="point")
 #' p2 <- qplot(1:10, (1:10)^2, geom="line") + theme_nothing()
-#' # simple grid
+#' # manually align and plot on top of each other
 #' aligned_plots <- align_plots(p1, p2, align="hv")
 #' ggdraw() + draw_grob(aligned_plots[[1]]) + draw_grob(aligned_plots[[2]])
 #' @export

--- a/R/switch_axis.R
+++ b/R/switch_axis.R
@@ -134,7 +134,7 @@ switch_xaxis_position <- function(gt, theme, keep.original = FALSE)
   g
 }
 
-#' Switches the axis position of the x or y axis in a ggplot2 plot.
+#' Switches the axis position of the x or y axis in a plot.
 #'
 #' @param plot The plot on which to perform the operation.
 #' @param axis String indicating which axis to switch. Valid options are"x", "y", and "xy".
@@ -166,7 +166,8 @@ switch_axis_position <- function(plot, axis = c('y', 'x', 'xy'), keep = c('none'
   )
 
   # extract gtable
-  gt <- ggplot2::ggplotGrob(plot)
+  gt <- ggplot_to_gtable(plot)
+
   # extract theme
   theme <- plot_theme(plot)
 


### PR DESCRIPTION
changed the switch_axis function to allow for gtable inputs. Also changed examples for the align_plots -- Also realized that function may not be that useful for individuals trying to get two different y axis and want to display both of them. May brainstorm how to alter align_plots function to work on two plots -- one that has normal y axis, and second that has switched y axis (current version cant handle that scenario).
