### PR TITLE
Fix ggplotGrob bug that saves a blank page

### DIFF
--- a/R/draw.R
+++ b/R/draw.R
@@ -7,7 +7,10 @@
 ggplot_to_gtable <- function(plot)
 {
   if (methods::is(plot, "ggplot")){
-    ggplot2::ggplotGrob(plot)
+    pdf(NULL)
+    plot <- ggplot2::ggplotGrob(plot)
+    dev.off()
+    plot
   }
   else if (methods::is(plot, "gtable")){
     plot

--- a/R/draw.R
+++ b/R/draw.R
@@ -7,6 +7,8 @@
 ggplot_to_gtable <- function(plot)
 {
   if (methods::is(plot, "ggplot")){
+    # ggplotGrob must open a device and when a multiple page capable device (e.g. PDF) is open this will save a blank page
+    # in order to avoid saving this blank page to the final target device a NULL device is opened and closed here to *absorb* the blank plot
     pdf(NULL)
     plot <- ggplot2::ggplotGrob(plot)
     dev.off()


### PR DESCRIPTION
The ggplotGrob function requires an open device and when a multiple page capable device is open (e.g. PDF) this will result in a blank page. This can be avoided by wrapping ggplotGrob with an open NULL device. 