### PR TITLE
get_legend error checking

### DIFF
--- a/R/get_legend.R
+++ b/R/get_legend.R
@@ -20,5 +20,13 @@
 get_legend <- function(plot)
 {
     grobs <- ggplot_to_gtable(plot)$grobs
-    legend <- grobs[[which(sapply(grobs, function(x) x$name) == "guide-box")]]
+    legendIndex <- which(sapply(grobs, function(x) x$name) == "guide-box")
+    ## make sure this plot has a legend to be extracted
+    ## note that multiple legends show up as one grob so this still works for multiple legend plots (i.e. color and shape)
+    ## not sure if it is possible to create a plot with multiple legend grobs, but also not sure how this function should handle those situations so this seems to be the best check to provide a useful message
+    if (length(legendIndex) == 1){
+        legend <- grobs[[legendIndex]]
+    } else {
+        stop('Plot must contain a legend')
+    }
 }


### PR DESCRIPTION
This is a bit of clean up from pull request #47. Added a check to make sure supplied plot has a legend when trying to extract the legend grob using get_legend. Throws a useful error message "Plot must contain a legend" instead of "attempt to select less than one element in get1index" error. This check does not throw an error on multiple legend plots as they are (in my testing) still contained within one grob, but it may be possible to create a plot with multiple legend grobs. This will now return an error, but I have not encountered this situation.