### PR TITLE
Enhance help files for draw_figure_label and draw_label

### DIFF
--- a/R/draw.R
+++ b/R/draw.R
@@ -133,14 +133,15 @@ draw_plot_label <- function(label, x=0, y=1, hjust = -0.5, vjust = 1.5, size = 1
 
 #' Add a label to a figure
 #'
-#' This function is similar to \code{draw_plot_label}, just with slightly different arguments and defaults. The main purpose of this
-#' function is to add labels specifying extra information about the figure, such as "Figure 1", which is sometimes useful.
+#' The main purpose of this function is to add labels specifying extra information about
+#' the figure, such as "Figure 1", or "A" - often useful in cowplots with more than
+#' one pane. The function is similar to \code{draw_plot_label}.
 #' @param label Label to be drawn
 #' @param position Position of the label, can be one of "top.left", "top", "top.right", "bottom.left", "bottom", "bottom.right". Default is "top.left"
 #' @param size (optional) Size of the label to be drawn. Default is the text size of the current theme
 #' @param fontface (optional) Font face of the label to be drawn. Default is the font face of the current theme
 #' @param ... other arguments passed to \code{draw_plot_label}
-#'
+#' @seealso \code{\link{draw_plot_label}}
 #' @examples
 #'
 #' p1 <- qplot(1:10, 1:10)

--- a/R/draw.R
+++ b/R/draw.R
@@ -26,30 +26,43 @@ draw_line <- function(x, y, ...){
             ...)
 }
 
-#' Draw text.
+#' Draw multiple text-strings in one go.
 #'
 #' This is a convenience function to plot multiple pieces of text at the same time. It cannot
 #' handle mathematical expressions, though. For those, use \code{draw_label}.
 #'
-#' Note that font sizes get scaled by a factor of 2.85, so sizes given here agree with font sizes used in
+#' Note that font sizes are scaled by a factor of 2.85, so sizes agree with those of
 #' the theme. This is different from \code{geom_text} in ggplot2.
 #'
 #' By default, the x and y coordinates specify the center of the text box. Set \code{hjust = 0, vjust = 0} to specify
 #' the lower left corner, and other values of \code{hjust} and \code{vjust} for any other relative location you want to
 #' specify.
-#' @param text Character or expression vector specifying the text to be written.
+#' 
+#' For a full list of ... options, see  \code{\link{geom_label}}.
+#' 
+#' @param text A vector of strings (not (yet) expressions) specifying the text(s) to be written.
 #' @param x Vector of x coordinates.
 #' @param y Vector of y coordinates.
+#' @param hjust (default = .5)
+#' @param vjust (default = .5)
 #' @param size Font size of the text to be drawn.
 #' @param ... Style parameters, such as \code{colour}, \code{alpha}, \code{angle}, \code{size}, etc.
+#' @seealso \code{\link{draw_label}}
 #' @examples
-#' ggdraw() + draw_text("Hello World!")
+#' # Draw onto a 1*1 piece of paper
+#' ggdraw() + draw_text("Hello World!", x = .5, y = .5)
+#' #
+#' # Adorn a plot from the famous Anscombe data set of "identical" data.
+#' p = qplot(x= x1, y= y1, geom = c("smooth", "point"), data = anscombe)
+#' p + draw_text(c("Hello World!", "to be or not to be", "over and out"), x = 8:10, y=5:7, hjust= 0)
 #' @export
-draw_text <- function(text, x = 0.5, y = 0.5, size = 14, ...){
+draw_text <- function(text, x = 0.5, y = 0.5, size = 14, hjust = .5, vjust = .5, ...){
   geom_text(data = data.frame(text, x, y),
-            aes(label = text, x = x, y = y),
-            size = size / .pt, # scale font size to match size in theme definition
+            aes(x = x, y = y, label = text),
+            size = (size / .pt), # scale font size to match size in theme definition
             inherit.aes = FALSE,
+			hjust = hjust, 
+			vjust = vjust,
             ...)
 }
 

--- a/R/draw.R
+++ b/R/draw.R
@@ -40,7 +40,7 @@ draw_line <- function(x, y, ...){
 #' 
 #' For a full list of ... options, see  \code{\link{geom_label}}.
 #' 
-#' @param text A vector of strings (not (yet) expressions) specifying the text(s) to be written.
+#' @param text A vector of Character (not expressions) specifying the string(s) to be written.
 #' @param x Vector of x coordinates.
 #' @param y Vector of y coordinates.
 #' @param hjust (default = 0.5)
@@ -52,7 +52,7 @@ draw_line <- function(x, y, ...){
 #' # Draw onto a 1*1 drawing surface
 #' ggdraw() + draw_text("Hello World!", x = 0.5, y = 0.5)
 #' #
-#' # Adorn a plot from the famous Anscombe data set of "identical" data.
+#' # Adorn a plot from the Anscombe data set of "identical" data.
 #' p = qplot(x = x1, y = y1, geom = c("smooth", "point"), data = anscombe)
 #' threeStrings = c("Hello World!", "to be or not to be", "over and out")
 #' p + draw_text(threeStrings, x = 8:10, y = 5:7, hjust = 0)

--- a/R/draw.R
+++ b/R/draw.R
@@ -43,20 +43,21 @@ draw_line <- function(x, y, ...){
 #' @param text A vector of strings (not (yet) expressions) specifying the text(s) to be written.
 #' @param x Vector of x coordinates.
 #' @param y Vector of y coordinates.
-#' @param hjust (default = .5)
-#' @param vjust (default = .5)
+#' @param hjust (default = 0.5)
+#' @param vjust (default = 0.5)
 #' @param size Font size of the text to be drawn.
 #' @param ... Style parameters, such as \code{colour}, \code{alpha}, \code{angle}, \code{size}, etc.
 #' @seealso \code{\link{draw_label}}
 #' @examples
-#' # Draw onto a 1*1 piece of paper
-#' ggdraw() + draw_text("Hello World!", x = .5, y = .5)
+#' # Draw onto a 1*1 drawing surface
+#' ggdraw() + draw_text("Hello World!", x = 0.5, y = 0.5)
 #' #
 #' # Adorn a plot from the famous Anscombe data set of "identical" data.
-#' p = qplot(x= x1, y= y1, geom = c("smooth", "point"), data = anscombe)
-#' p + draw_text(c("Hello World!", "to be or not to be", "over and out"), x = 8:10, y=5:7, hjust= 0)
+#' p = qplot(x = x1, y = y1, geom = c("smooth", "point"), data = anscombe)
+#' threeStrings = c("Hello World!", "to be or not to be", "over and out")
+#' p + draw_text(threeStrings, x = 8:10, y = 5:7, hjust = 0)
 #' @export
-draw_text <- function(text, x = 0.5, y = 0.5, size = 14, hjust = .5, vjust = .5, ...){
+draw_text <- function(text, x = 0.5, y = 0.5, size = 14, hjust = 0.5, vjust = 0.5, ...){
   geom_text(data = data.frame(text, x, y),
             aes(x = x, y = y, label = text),
             size = (size / .pt), # scale font size to match size in theme definition
@@ -79,8 +80,8 @@ draw_text <- function(text, x = 0.5, y = 0.5, size = 14, hjust = .5, vjust = .5,
 #' @param label String or plotmath expression to be drawn.
 #' @param x The x location (origin) of the label.
 #' @param y The y location (origin) of the label.
-#' @param hjust Horizontal justification. Default = .5 (centred on x). 0 = flush-left at x, 1 = flush-right.
-#' @param vjust Vertical justification. Default = .5 (centred on y). 0 = baseline at y, 1= ascender at y.
+#' @param hjust Horizontal justification. Default = 0.5 (centered on x). 0 = flush-left at x, 1 = flush-right.
+#' @param vjust Vertical justification. Default = 0.5 (centered on y). 0 = baseline at y, 1 = ascender at y.
 #' @param fontfamily The font family
 #' @param fontface The font face ("plain", "bold", etc.)
 #' @param colour Text color
@@ -91,8 +92,8 @@ draw_text <- function(text, x = 0.5, y = 0.5, size = 14, hjust = .5, vjust = .5,
 #' @seealso \code{\link{ggdraw}}
 #' @examples
 #' # setup plot and a label (regression description)
-#' p <- ggplot(mtcars, aes(mpg, disp)) + geom_line(colour = "blue") + background_grid(minor='none')
-#' c <- cor.test(mtcars$mpg, mtcars$disp, method='sp')
+#' p <- ggplot(mtcars, aes(mpg, disp)) + geom_line(color = "blue") + background_grid(minor = 'none')
+#' c <- cor.test(mtcars$mpg, mtcars$disp, method = 'sp')
 #' label <- substitute(paste("Spearman ", rho, " = ", estimate, ", P = ", pvalue),
 #'                     list(estimate = signif(c$estimate, 2), pvalue = signif(c$p.value, 2)))
 #' 
@@ -105,17 +106,14 @@ draw_text <- function(text, x = 0.5, y = 0.5, size = 14, hjust = .5, vjust = .5,
 #' # from x, with ascenders of text touching y.
 #' p + draw_label(label, x = 20, y = 400, hjust = 0, vjust = 1)
 #' 
-#' 
-# ===================================================
-# = Add labels via ggdraw. Uses ggdraw coordinates. =
-# ===================================================
+#' # Add labels via ggdraw. Uses ggdraw coordinates.
 #' # ggdraw coordinates default to xlim = c(0, 1), ylim = c(0, 1).
-#' ggdraw(p) + draw_label("Centred on 70% of x, 90% of y height", x = .7, y = .9)
+#' ggdraw(p) + draw_label("centered on 70% of x, 90% of y height", x = 0.7, y = 0.9)
 #' labstr = "bottom left at {0%, 0%} of the SHEET, not the plot!"
-#' p = ggdraw(p) + draw_label(labstr, x = 0, y = 0, hjust = 0, vjust=0)
-#' p = p + draw_label("top right at {1,1}", x = 1, y = 1, hjust = 1, vjust=1)
-#' p = p + draw_label("bottom left at {.4,.4}", x = .4, y = .4, hjust = 0, vjust=0)
-#' p + draw_label("centred on at {.5,.5}", x = .5, y = .5, hjust = .5, vjust=.5)
+#' p = ggdraw(p) + draw_label(labstr, x = 0, y = 0, hjust = 0, vjust = 0)
+#' p = p + draw_label("top right at {1,1}", x = 1, y = 1, hjust = 1, vjust = 1)
+#' p = p + draw_label("bottom left at {.4,.4}", x = 0.4, y = 0.4, hjust = 0, vjust = 0)
+#' p + draw_label("centered on at {.5,.5}", x = 0.5, y = 0.5, hjust = 0.5, vjust = 0.5)
 #' @export
 draw_label <- function(label, x = 0.5, y = 0.5, hjust = 0.5, vjust = 0.5,
                     fontfamily = "", fontface = "plain", colour = "black", size = 14,
@@ -151,7 +149,7 @@ draw_label <- function(label, x = 0.5, y = 0.5, hjust = 0.5, vjust = 0.5,
 #' @param colour (optional) Color of the plot labels. If not provided, is taken from the current theme.
 #' @param ... Other arguments to be handed to \code{draw_text}.
 #' @export
-draw_plot_label <- function(label, x=0, y=1, hjust = -0.5, vjust = 1.5, size = 16, fontface = 'bold',
+draw_plot_label <- function(label, x = 0, y = 1, hjust = -0.5, vjust = 1.5, size = 16, fontface = 'bold',
                             family = NULL, colour = NULL, ...){
   if (is.null(family)) {
     family <- theme_get()$text$family
@@ -246,7 +244,7 @@ draw_figure_label <- function(label, position = c("top.left", "top", "top.right"
 #'  (the alternative is to use nearest-neighbour interpolation, which gives a more blocky result).
 #' @examples
 #' # Use image as plot background
-#' p <- ggplot(iris, aes(x=Sepal.Length, fill=Species)) + geom_density(alpha = 0.7)
+#' p <- ggplot(iris, aes(x = Sepal.Length, fill = Species)) + geom_density(alpha = 0.7)
 #' ggdraw() +
 #'   draw_image("http://jeroen.github.io/images/tiger.svg") +
 #'   draw_plot(p + theme(legend.box.background = element_rect(color = "white")))
@@ -256,14 +254,15 @@ draw_figure_label <- function(label, position = c("top.left", "top", "top.right"
 #' img <- magick::image_transparent(img, color = "white")
 #' img2 <- magick::image_charcoal(img)
 #' img2 <- magick::image_transparent(img2, color = "white")
-#' ggplot(data.frame(x=1:3, y=1:3), aes(x, y)) +
+#' ggplot(data.frame(x = 1:3, y = 1:3), aes(x, y)) +
 #'   geom_point(size = 3) +
 #'   geom_abline(slope = 1, intercept = 0, linetype = 2, color = "blue") +
-#'   draw_image(img, x=1, y=1, scale = .9) +
-#'   draw_image(img2, x=2, y=2, scale = .9)
+#'   draw_image(img , x = 1, y = 1, scale = .9) +
+#'   draw_image(img2, x = 2, y = 2, scale = .9)
 #'
 #' # Make grid with plot and image
-#' p <- ggplot(iris, aes(x=Sepal.Length, fill=Species)) + geom_density(alpha = 0.7)
+#' p <- ggplot(iris, aes(x = Sepal.Length, fill = Species)) +
+#'   geom_density(alpha = 0.7)
 #' p2 <- ggdraw() + draw_image("http://jeroen.github.io/images/tiger.svg", scale = 0.9)
 #' plot_grid(p, p2, labels = "AUTO")
 #' @export
@@ -404,13 +403,12 @@ annotation_id <- local({
 #' ggdraw(p) + draw_label("Draft", colour = "grey", size = 120, angle = 45)
 #' @export
 ggdraw <- function(plot = NULL, xlim = c(0, 1), ylim = c(0, 1)) {
-
-  d <- data.frame(x=0:1, y=0:1) # dummy data
-  p <- ggplot(d, aes_string(x="x", y="y")) + # empty plot
+  d <- data.frame(x = 0:1, y = 0:1) # dummy data
+  p <- ggplot(d, aes_string(x = "x", y = "y")) + # empty plot
     scale_x_continuous(limits = xlim, expand = c(0, 0)) +
     scale_y_continuous(limits = ylim, expand = c(0, 0)) +
     theme_nothing() + # with empty theme
-    labs(x=NULL, y=NULL) # and absolutely no axes
+    labs(x = NULL, y = NULL) # and absolutely no axes
 
   if (!is.null(plot)){
     p <- p + draw_plot(plot)

--- a/R/draw.R
+++ b/R/draw.R
@@ -61,10 +61,10 @@ draw_text <- function(text, x = 0.5, y = 0.5, size = 14, ...){
 #' the lower left corner, and other values of \code{hjust} and \code{vjust} for any other relative location you want to
 #' specify.
 #' @param label String or plotmath expression to be drawn.
-#' @param x The x location of the label.
-#' @param y The y location of the label.
-#' @param hjust Horizontal justification
-#' @param vjust Vertical justification
+#' @param x The x location (origin) of the label.
+#' @param y The y location (origin) of the label.
+#' @param hjust Horizontal justification. Default = .5 (centred on x). 0 = flush-left at x, 1 = flush-right.
+#' @param vjust Vertical justification. Default = .5 (centred on y). 0 = baseline at y, 1= ascender at y.
 #' @param fontfamily The font family
 #' @param fontface The font face ("plain", "bold", etc.)
 #' @param colour Text color
@@ -72,15 +72,34 @@ draw_text <- function(text, x = 0.5, y = 0.5, size = 14, ...){
 #' @param angle Angle at which text is drawn
 #' @param lineheight Line height of text
 #' @param alpha The alpha value of the text
+#' @seealso \code{\link{ggdraw}}
 #' @examples
+#' # setup plot and a label (regression description)
 #' p <- ggplot(mtcars, aes(mpg, disp)) + geom_line(colour = "blue") + background_grid(minor='none')
 #' c <- cor.test(mtcars$mpg, mtcars$disp, method='sp')
 #' label <- substitute(paste("Spearman ", rho, " = ", estimate, ", P = ", pvalue),
 #'                     list(estimate = signif(c$estimate, 2), pvalue = signif(c$p.value, 2)))
-#' # adding label via ggdraw, in the ggdraw coordinates
-#' ggdraw(p) + draw_label(label, .7, .9)
-#' # adding label directly to plot, in the data coordinates
-#' p + draw_label(label, 20, 400, hjust = 0, vjust = 0)
+#' 
+#' # Add label to plot, centered on {x,y} (in data coordinates)
+#' p + draw_label(label, x = 20, y = 400)
+#' # Add label to plot in data coordinates, flush-left at x, baseline at y.
+#' p + draw_label(label, x = 20, y = 400, hjust = 0, vjust = 0)
+#'
+#' # Add label to plot. Data coordinates, drawing rightward 
+#' # from x, with ascenders of text touching y.
+#' p + draw_label(label, x = 20, y = 400, hjust = 0, vjust = 1)
+#' 
+#' 
+# ===================================================
+# = Add labels via ggdraw. Uses ggdraw coordinates. =
+# ===================================================
+#' # ggdraw coordinates default to xlim = c(0, 1), ylim = c(0, 1).
+#' ggdraw(p) + draw_label("Centred on 70% of x, 90% of y height", x = .7, y = .9)
+#' labstr = "bottom left at {0%, 0%} of the SHEET, not the plot!"
+#' p = ggdraw(p) + draw_label(labstr, x = 0, y = 0, hjust = 0, vjust=0)
+#' p = p + draw_label("top right at {1,1}", x = 1, y = 1, hjust = 1, vjust=1)
+#' p = p + draw_label("bottom left at {.4,.4}", x = .4, y = .4, hjust = 0, vjust=0)
+#' p + draw_label("centred on at {.5,.5}", x = .5, y = .5, hjust = .5, vjust=.5)
 #' @export
 draw_label <- function(label, x = 0.5, y = 0.5, hjust = 0.5, vjust = 0.5,
                     fontfamily = "", fontface = "plain", colour = "black", size = 14,

--- a/R/draw.R
+++ b/R/draw.R
@@ -4,16 +4,19 @@
 
 
 
-#' Draw a line.
+#' Draw a line from connected points
 #'
-#' This is a convenience function. It's just a thin wrapper around \code{geom_line}.
+#' Provide a sequence of x values and accompanying y values to draw a line on a plot.
+#' 
+#' This is a convenience function, providing a wrapper around ggplot2's \code{geom_path}.
 #'
 #' @param x Vector of x coordinates.
 #' @param y Vector of y coordinates.
-#' @param ... Style parameters, such as \code{colour}, \code{alpha}, \code{size}, etc.
+#' @param ... geom_path parameters such as \code{colour}, \code{alpha}, \code{size}, etc.
+#' @seealso \code{\link{geom_path}}, \code{\link{ggdraw}}
 #' @examples
-#' ggdraw() + draw_line(c(0.2, 0.7, 0.7, 0.3),
-#'                      c(0.1, 0.3, 0.9, 0.8),
+#' ggdraw() + draw_line(x = c(0.2, 0.7, 0.7, 0.3),
+#'                      y = c(0.1, 0.3, 0.9, 0.8),
 #'                      color = "blue", size = 2)
 #' @export
 draw_line <- function(x, y, ...){

--- a/man/draw_figure_label.Rd
+++ b/man/draw_figure_label.Rd
@@ -50,7 +50,7 @@ ggdraw(p2) + draw_figure_label(label = "Figure 1", position = "bottom.right", si
 
 }
 \seealso{
-draw_plot_label
+\code{\link{draw_plot_label}}
 }
 \author{
 Ulrik Stervbo (ulrik.stervbo @ gmail.com)

--- a/man/draw_figure_label.Rd
+++ b/man/draw_figure_label.Rd
@@ -19,8 +19,9 @@ draw_figure_label(label, position = c("top.left", "top", "top.right",
 \item{...}{other arguments passed to \code{draw_plot_label}}
 }
 \description{
-This function is similar to \code{draw_plot_label}, just with slightly different arguments and defaults. The main purpose of this
-function is to add labels specifying extra information about the figure, such as "Figure 1", which is sometimes useful.
+The main purpose of this function is to add labels specifying extra information about
+the figure, such as "Figure 1", or "A" - often useful in cowplots with more than
+one pane. The function is similar to \code{draw_plot_label}.
 }
 \examples{
 
@@ -47,6 +48,9 @@ p + draw_figure_label(label = "Figure 1", angle = -45, colour = "red")
 # Labeling an individual plot
 ggdraw(p2) + draw_figure_label(label = "Figure 1", position = "bottom.right", size = 10)
 
+}
+\seealso{
+draw_plot_label
 }
 \author{
 Ulrik Stervbo (ulrik.stervbo @ gmail.com)

--- a/man/draw_label.Rd
+++ b/man/draw_label.Rd
@@ -11,13 +11,13 @@ draw_label(label, x = 0.5, y = 0.5, hjust = 0.5, vjust = 0.5,
 \arguments{
 \item{label}{String or plotmath expression to be drawn.}
 
-\item{x}{The x location of the label.}
+\item{x}{The x location (origin) of the label.}
 
-\item{y}{The y location of the label.}
+\item{y}{The y location (origin) of the label.}
 
-\item{hjust}{Horizontal justification}
+\item{hjust}{Horizontal justification. Default = .5 (centred on x). 0 = flush-left at x, 1 = flush-right.}
 
-\item{vjust}{Vertical justification}
+\item{vjust}{Vertical justification. Default = .5 (centred on y). 0 = baseline at y, 1= ascender at y.}
 
 \item{fontfamily}{The font family}
 
@@ -44,12 +44,30 @@ the lower left corner, and other values of \code{hjust} and \code{vjust} for any
 specify.
 }
 \examples{
+# setup plot and a label (regression description)
 p <- ggplot(mtcars, aes(mpg, disp)) + geom_line(colour = "blue") + background_grid(minor='none')
 c <- cor.test(mtcars$mpg, mtcars$disp, method='sp')
 label <- substitute(paste("Spearman ", rho, " = ", estimate, ", P = ", pvalue),
                     list(estimate = signif(c$estimate, 2), pvalue = signif(c$p.value, 2)))
-# adding label via ggdraw, in the ggdraw coordinates
-ggdraw(p) + draw_label(label, .7, .9)
-# adding label directly to plot, in the data coordinates
-p + draw_label(label, 20, 400, hjust = 0, vjust = 0)
+
+# Add label to plot, centered on {x,y} (in data coordinates)
+p + draw_label(label, x = 20, y = 400)
+# Add label to plot in data coordinates, flush-left at x, baseline at y.
+p + draw_label(label, x = 20, y = 400, hjust = 0, vjust = 0)
+
+# Add label to plot. Data coordinates, drawing rightward 
+# from x, with ascenders of text touching y.
+p + draw_label(label, x = 20, y = 400, hjust = 0, vjust = 1)
+
+
+# ggdraw coordinates default to xlim = c(0, 1), ylim = c(0, 1).
+ggdraw(p) + draw_label("Centred on 70\% of x, 90\% of y height", x = .7, y = .9)
+labstr = "bottom left at {0\%, 0\%} of the SHEET, not the plot!"
+p = ggdraw(p) + draw_label(labstr, x = 0, y = 0, hjust = 0, vjust=0)
+p = p + draw_label("top right at {1,1}", x = 1, y = 1, hjust = 1, vjust=1)
+p = p + draw_label("bottom left at {.4,.4}", x = .4, y = .4, hjust = 0, vjust=0)
+p + draw_label("centred on at {.5,.5}", x = .5, y = .5, hjust = .5, vjust=.5)
+}
+\seealso{
+\code{\link{ggdraw}}
 }

--- a/man/draw_line.Rd
+++ b/man/draw_line.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/draw.R
 \name{draw_line}
 \alias{draw_line}
-\title{Draw a line.}
+\title{Draw a line from connected points}
 \usage{
 draw_line(x, y, ...)
 }
@@ -11,13 +11,19 @@ draw_line(x, y, ...)
 
 \item{y}{Vector of y coordinates.}
 
-\item{...}{Style parameters, such as \code{colour}, \code{alpha}, \code{size}, etc.}
+\item{...}{geom_path parameters such as \code{colour}, \code{alpha}, \code{size}, etc.}
 }
 \description{
-This is a convenience function. It's just a thin wrapper around \code{geom_line}.
+Provide a sequence of x values and accompanying y values to draw a line on a plot.
+}
+\details{
+This is a convenience function, providing a wrapper around ggplot2's \code{geom_path}.
 }
 \examples{
-ggdraw() + draw_line(c(0.2, 0.7, 0.7, 0.3),
-                     c(0.1, 0.3, 0.9, 0.8),
+ggdraw() + draw_line(x = c(0.2, 0.7, 0.7, 0.3),
+                     y = c(0.1, 0.3, 0.9, 0.8),
                      color = "blue", size = 2)
+}
+\seealso{
+\code{\link{geom_path}}, \code{\link{ggdraw}}
 }

--- a/man/draw_text.Rd
+++ b/man/draw_text.Rd
@@ -2,18 +2,23 @@
 % Please edit documentation in R/draw.R
 \name{draw_text}
 \alias{draw_text}
-\title{Draw text.}
+\title{Draw multiple text-strings in one go.}
 \usage{
-draw_text(text, x = 0.5, y = 0.5, size = 14, ...)
+draw_text(text, x = 0.5, y = 0.5, size = 14, hjust = 0.5, vjust = 0.5,
+  ...)
 }
 \arguments{
-\item{text}{Character or expression vector specifying the text to be written.}
+\item{text}{A vector of strings (not (yet) expressions) specifying the text(s) to be written.}
 
 \item{x}{Vector of x coordinates.}
 
 \item{y}{Vector of y coordinates.}
 
 \item{size}{Font size of the text to be drawn.}
+
+\item{hjust}{(default = .5)}
+
+\item{vjust}{(default = .5)}
 
 \item{...}{Style parameters, such as \code{colour}, \code{alpha}, \code{angle}, \code{size}, etc.}
 }
@@ -22,13 +27,19 @@ This is a convenience function to plot multiple pieces of text at the same time.
 handle mathematical expressions, though. For those, use \code{draw_label}.
 }
 \details{
-Note that font sizes get scaled by a factor of 2.85, so sizes given here agree with font sizes used in
+Note that font sizes are scaled by a factor of 2.85, so sizes agree with those of
 the theme. This is different from \code{geom_text} in ggplot2.
 
 By default, the x and y coordinates specify the center of the text box. Set \code{hjust = 0, vjust = 0} to specify
 the lower left corner, and other values of \code{hjust} and \code{vjust} for any other relative location you want to
 specify.
+
+For a full list of ... options, see  \code{\link{geom_label}}.
 }
 \examples{
-ggdraw() + draw_text("Hello World!")
+ggdraw() + draw_text(c("Hello World!", "to be or not to be", "over and out"), x = 1:3, y=1:3)
+ggdraw() + draw_text("Hello World!", x = 1, y = 2)
+}
+\seealso{
+\code{\link{draw_label}}
 }


### PR DESCRIPTION
I think these edits might help people pick the functions they need (for instance, make  draw_figure_label, more discoverable by putting its purpose first in description).

Also aid understanding of  complex things like hjust and coordinates, by giving examples with labeled parameters, labels which say where they were placed, and more help text among examples.

Finally, more fulsome  labels for @params to help people understand them.