### PR TITLE
Allow get_legend to return NULL when there is no legend

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,8 @@ breaking changes were introduced:
 Other breaking changes:
 - The defaults for `save_plot()` were changed somewhat. This may require
   adjustment if you have code depending on it.
+- `get_legend()` now returns NULL if there is no legend instead of raising
+  an error.
 
 ## New features
 - Added a function `as_grob()` that can convert base plots, lattice plots,

--- a/R/get_legend.R
+++ b/R/get_legend.R
@@ -3,6 +3,7 @@
 #' This function extracts just the legend from a ggplot
 #'
 #' @param plot A ggplot or gtable from which to retrieve the legend
+#' @param allow_null_legend Return \code{NULL} if there is no legend?
 #' @return A gtable object holding just the lengend
 #' @examples
 #' library(ggplot2)
@@ -20,7 +21,7 @@
 #'                  plot_grid(NULL, legend, ncol=1),
 #'                  rel_widths=c(1, 0.2)))
 #' @export
-get_legend <- function(plot)
+get_legend <- function(plot, allow_null_legend=FALSE)
 {
     grobs <- as_gtable(plot)$grobs
     legendIndex <- which(sapply(grobs, function(x) x$name) == "guide-box")
@@ -29,6 +30,8 @@ get_legend <- function(plot)
     ## not sure if it is possible to create a plot with multiple legend grobs, but also not sure how this function should handle those situations so this seems to be the best check to provide a useful message
     if (length(legendIndex) == 1){
         legend <- grobs[[legendIndex]]
+    } else if (allow_null_legend) {
+        legend <- NULL
     } else {
         stop('Plot must contain a legend')
     }

--- a/R/get_legend.R
+++ b/R/get_legend.R
@@ -3,8 +3,7 @@
 #' This function extracts just the legend from a ggplot
 #'
 #' @param plot A ggplot or gtable from which to retrieve the legend
-#' @param allow_null_legend Return \code{NULL} if there is no legend?
-#' @return A gtable object holding just the lengend
+#' @return A gtable object holding just the legend or \code{NULL} if there is no legend.
 #' @examples
 #' library(ggplot2)
 #' theme_set(theme_half_open())
@@ -21,7 +20,7 @@
 #'                  plot_grid(NULL, legend, ncol=1),
 #'                  rel_widths=c(1, 0.2)))
 #' @export
-get_legend <- function(plot, allow_null_legend=FALSE)
+get_legend <- function(plot)
 {
     grobs <- as_gtable(plot)$grobs
     legendIndex <- which(sapply(grobs, function(x) x$name) == "guide-box")
@@ -30,9 +29,7 @@ get_legend <- function(plot, allow_null_legend=FALSE)
     ## not sure if it is possible to create a plot with multiple legend grobs, but also not sure how this function should handle those situations so this seems to be the best check to provide a useful message
     if (length(legendIndex) == 1){
         legend <- grobs[[legendIndex]]
-    } else if (allow_null_legend) {
-        legend <- NULL
     } else {
-        stop('Plot must contain a legend')
+        legend <- NULL
     }
 }

--- a/man/get_legend.Rd
+++ b/man/get_legend.Rd
@@ -4,15 +4,13 @@
 \alias{get_legend}
 \title{Retrieve the legend of a plot}
 \usage{
-get_legend(plot, allow_null_legend = FALSE)
+get_legend(plot)
 }
 \arguments{
 \item{plot}{A ggplot or gtable from which to retrieve the legend}
-
-\item{allow_null_legend}{Return \code{NULL} if there is no legend?}
 }
 \value{
-A gtable object holding just the lengend
+A gtable object holding just the legend or \code{NULL} if there is no legend.
 }
 \description{
 This function extracts just the legend from a ggplot

--- a/man/get_legend.Rd
+++ b/man/get_legend.Rd
@@ -4,10 +4,12 @@
 \alias{get_legend}
 \title{Retrieve the legend of a plot}
 \usage{
-get_legend(plot)
+get_legend(plot, allow_null_legend = FALSE)
 }
 \arguments{
 \item{plot}{A ggplot or gtable from which to retrieve the legend}
+
+\item{allow_null_legend}{Return \code{NULL} if there is no legend?}
 }
 \value{
 A gtable object holding just the lengend

--- a/tests/testthat/test_get_legend.R
+++ b/tests/testthat/test_get_legend.R
@@ -8,10 +8,7 @@ test_that("get legend", {
   expect_s3_class(l, "gtable")
   expect_equal(l$name, "guide-box")
 
-  # cannot extract a legend when none exists
-  expect_error(get_legend(p + theme(legend.position = "none")))
-  # return a null legend if allowed
-  expect_null(get_legend(p + theme(legend.position = "none"),
-                         allow_null_legend=TRUE))
+  # return null legend if no legend
+  expect_null(get_legend(p + theme(legend.position = "none")))
 })
 

--- a/tests/testthat/test_get_legend.R
+++ b/tests/testthat/test_get_legend.R
@@ -10,5 +10,8 @@ test_that("get legend", {
 
   # cannot extract a legend when none exists
   expect_error(get_legend(p + theme(legend.position = "none")))
+  # return a null legend if allowed
+  expect_null(get_legend(p + theme(legend.position = "none"),
+                         allow_null_legend=TRUE))
 })
 


### PR DESCRIPTION
Fix #98 

Due to the requirement of ggplot more recent than that on CRAN, I wrote the code and the test, but I couldn't actually test it (and I need the current CRAN version instead of development on my local system).