### PR TITLE
added dpi to set_null_device

### DIFF
--- a/R/set_null_device.R
+++ b/R/set_null_device.R
@@ -82,7 +82,7 @@ cairo_null_device <- function(width, height) {
     Cairo::Cairo(
       type = "raster",
       width = width, height = height,
-      units = "in"
+      units = "in", dpi=300
     )
     grDevices::dev.control("enable")
   } else {

--- a/R/set_null_device.R
+++ b/R/set_null_device.R
@@ -82,7 +82,7 @@ cairo_null_device <- function(width, height) {
     Cairo::Cairo(
       type = "raster",
       width = width, height = height,
-      units = "in", dpi=300
+      units = "in", dpi = 300
     )
     grDevices::dev.control("enable")
   } else {


### PR DESCRIPTION
Given that I work on macOS, it took me some time to set up an environment where I can use custom fonts in ggplot2 that are non-standard. The workflow makes use of `showtext` and specifies cairo-devices in `knitr::opts_chunk$set`.
I found that using this setup does not work without warnings in `cowplot` (complaining about the font that is not found), so my aim was to also set the null device of `cowplot` to cairo (which also fixed these warnings in other instances).

However, using `cowplot::set_null_device("cairo")` yields an error, stating that `images cannot be created with other units than 'px' if dpi is not specified`. A small change (adding the `dpi = ` argument) fixed this error, enabling of setting the null device.
Importantly, after this change my workflow with custom fonts worked again.

Could make this change to the source code?

PS: probably dpi can also be set to "auto" if preferred.