### PR TITLE
Adds functionality to align plots by axis values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cowplot
 Title: Streamlined Plot Theme and Plot Annotations for 'ggplot2'
-Version: 1.1.2
+Version: 1.1.2.9001
 Authors@R:
     person(
       given = "Claus O.",
@@ -72,6 +72,6 @@ Collate:
     'stamp.R'
     'themes.R'
     'utils_ggplot2.R'
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/R/align_plots.R
+++ b/R/align_plots.R
@@ -188,7 +188,7 @@ align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
   # convert list of plots into list of grobs / gtables
   grobs <- lapply(plots, function(x) {if (!is.null(x)) as_gtable(x) else NULL})
 
-  #aligning graphs.
+  # aligning graphs.
   halign <- switch(
     align[1],
     h = TRUE,
@@ -232,7 +232,7 @@ align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
       # Complex aligns are ones that don't have the same number of elements that have sizes
       # or for which explicit axis alignment is requested
       vcomplex_align = TRUE
-      if(axis[1] == "none") {
+      if (axis[1] == "none") {
         warning(
           "Graphs cannot be vertically aligned unless the axis parameter is set. Placing graphs unaligned.",
           call. = FALSE
@@ -250,7 +250,7 @@ align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
         max_widths <- align_margin(max_widths, "last", greedy = greedy)
       }
     } else {
-      max_widths <- list(do.call(grid::unit.pmax, lapply(grobs, function(x){x$widths})))
+      max_widths <- list(do.call(grid::unit.pmax, lapply(grobs, function(x) {x$widths})))
     }
   }
 
@@ -279,7 +279,7 @@ align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
       # Complex aligns are ones that don't have the same number of elements that have sizes
       # or for which explicit axis alignment is requested
       hcomplex_align = TRUE
-      if (axis[1] == "none"){
+      if (axis[1] == "none") {
         warning(
           "Graphs cannot be horizontally aligned unless the axis parameter is set. Placing graphs unaligned.",
           call. = FALSE
@@ -297,7 +297,7 @@ align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
       }
 
     } else {
-      max_heights <- list(do.call(grid::unit.pmax, lapply(grobs, function(x){x$heights})))
+      max_heights <- list(do.call(grid::unit.pmax, lapply(grobs, function(x) {x$heights})))
     }
   }
 
@@ -305,7 +305,7 @@ align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
   for (i in 1:num_plots) {
     if (!is.null(grobs[[i]])) {
       if (valign) {
-        if(vcomplex_align) {
+        if (vcomplex_align) {
           grobs[[i]]$widths <- max_widths[[i]]
         } else{
           grobs[[i]]$widths <- max_widths[[1]]
@@ -327,7 +327,7 @@ align_plots <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
         }
       }
       if (halign) {
-        if(hcomplex_align){
+        if (hcomplex_align) {
           grobs[[i]]$heights <- max_heights[[i]]
         } else{
           grobs[[i]]$heights <- max_heights[[1]]

--- a/R/plot_grid.R
+++ b/R/plot_grid.R
@@ -40,6 +40,8 @@
 #' @param byrow Logical value indicating if the plots should be arrange by row (default) or by column.
 #' @param rows Deprecated. Use \code{nrow}.
 #' @param cols Deprecated. Use \code{ncol}.
+#' @param align_axis (optional) If set to TRUE, the axis are aligned and adjusted by their values.
+#'
 #' @examples
 #' library(ggplot2)
 #'
@@ -85,6 +87,20 @@
 #'   p1, p5,
 #'   align = "h", axis = "b", nrow = 1, rel_widths = c(1, 2)
 #' )
+#'
+#' # aligning two plots by their x axis values
+#' p1 <- ggplot(mtcars, aes(x = disp, y = mpg)) +
+#'   geom_point()
+#' p2 <- ggplot(mtcars[mtcars$disp > 300, ], aes(x = disp, y = mpg)) +
+#'   geom_point()
+#' 
+#' plot_grid(p1, p2, ncol = 1, align = "v",  align_axis = TRUE)
+#' 
+#' # align horizontally
+#' p3 <- ggplot(mtcars[mtcars$mpg > 20, ], aes(x = disp, y = mpg)) +
+#'   geom_point()
+#' 
+#' plot_grid(p1, p3, nrow = 1, align = "h",  align_axis = TRUE)
 #'
 #' # more examples
 #' \donttest{
@@ -139,7 +155,7 @@ plot_grid <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
                       label_fontfamily = NULL, label_fontface = "bold", label_colour = NULL,
                       label_x = 0, label_y = 1,
                       hjust = -0.5, vjust = 1.5, scale = 1., greedy = TRUE,
-                      byrow = TRUE, cols = NULL, rows = NULL) {
+                      byrow = TRUE, cols = NULL, rows = NULL, align_axis = FALSE) {
 
   # Make a list from the ... arguments and plotlist
   plots <- c(list(...), plotlist)
@@ -181,7 +197,8 @@ plot_grid <- function(..., plotlist = NULL, align = c("none", "h", "v", "hv"),
   if (!isTRUE(byrow)) plots <- plots[c(t(matrix(c(1:num_plots, rep(NA, (rows * cols) - num_plots)), nrow = rows, byrow = FALSE)))]
 
   # Align the plots (if specified)
-  grobs <- align_plots(plotlist = plots, align = align, axis = axis, greedy = greedy)
+  grobs <- align_plots(plotlist = plots, align = align, axis = axis,
+                       greedy = greedy, align_axis = align_axis)
 
   if ("AUTO" %in% labels)
     labels <- LETTERS[1:num_plots]

--- a/man/align_plots.Rd
+++ b/man/align_plots.Rd
@@ -9,7 +9,8 @@ align_plots(
   plotlist = NULL,
   align = c("none", "h", "v", "hv"),
   axis = c("none", "l", "r", "t", "b", "lr", "tb", "tblr"),
-  greedy = TRUE
+  greedy = TRUE,
+  align_axis = FALSE
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ margins. Options are \code{axis="none"} (default), or a string of any combinatio
 \item{greedy}{(optional) Defines the alignment policy when alignment axes are specified via the
 \code{axis} option. \code{greedy = TRUE} tries to always align by adjusting the outmost margin. \code{greedy = FALSE}
 aligns all columns/rows in the gtable if possible.}
+
+\item{align_axis}{(optional) If set to TRUE, the axis are aligned and adjusted by their values.}
 }
 \description{
 Align the plot area of multiple plots. Inputs are a list of plots plus alignment parameters.

--- a/man/plot_grid.Rd
+++ b/man/plot_grid.Rd
@@ -26,7 +26,8 @@ plot_grid(
   greedy = TRUE,
   byrow = TRUE,
   cols = NULL,
-  rows = NULL
+  rows = NULL,
+  align_axis = FALSE
 )
 }
 \arguments{
@@ -90,6 +91,8 @@ sometimes be more powerful.}
 \item{cols}{Deprecated. Use \code{ncol}.}
 
 \item{rows}{Deprecated. Use \code{nrow}.}
+
+\item{align_axis}{(optional) If set to TRUE, the axis are aligned and adjusted by their values.}
 }
 \description{
 Arrange multiple plots into a grid.
@@ -139,6 +142,20 @@ plot_grid(
   p1, p5,
   align = "h", axis = "b", nrow = 1, rel_widths = c(1, 2)
 )
+
+# aligning two plots by their x axis values
+p1 <- ggplot(mtcars, aes(x = disp, y = mpg)) +
+  geom_point()
+p2 <- ggplot(mtcars[mtcars$disp > 300, ], aes(x = disp, y = mpg)) +
+  geom_point()
+
+plot_grid(p1, p2, ncol = 1, align = "v",  align_axis = TRUE)
+
+# align horizontally
+p3 <- ggplot(mtcars[mtcars$mpg > 20, ], aes(x = disp, y = mpg)) +
+  geom_point()
+
+plot_grid(p1, p3, nrow = 1, align = "h",  align_axis = TRUE)
 
 # more examples
 \donttest{

--- a/tests/testthat/test_align_plots.R
+++ b/tests/testthat/test_align_plots.R
@@ -141,3 +141,26 @@ test_that("complex alignments with non-plots", {
 
   dev.off()
 })
+
+
+test_that("align by axis", {
+  p1 <- ggplot(mtcars, aes(x = disp, y = mpg)) +
+    geom_point()
+  p2 <- ggplot(mtcars[mtcars$disp > 300, ], aes(x = disp, y = mpg)) +
+    geom_point()
+  p3 <- ggplot(mtcars[mtcars$mpg > 20, ], aes(x = disp, y = mpg)) +
+    geom_point()
+
+  plots <- align_plots(p1, p2, align = "v", align_axis = TRUE)
+  # vertical alignment -> same height
+  expect_equal(capture.output(plots[[1]]$heights),
+               capture.output(plots[[2]]$heights))
+  # note there is a string difference in some subpart of plot$heights,
+  # not sure why or how to access it;
+  # comparing what is printed in units is probably better than nothing...
+
+  plots <- align_plots(p1, p3, align = "v", align_axis = TRUE)
+  # horizontal alignment -> same width
+  expect_equal(capture.output(plots[[1]]$widths),
+               capture.output(plots[[2]]$widths))
+})

--- a/tests/testthat/test_plot_grid.R
+++ b/tests/testthat/test_plot_grid.R
@@ -98,3 +98,22 @@ test_that("alignment", {
     plot_grid(p1, p2, ncol = 1, align = 'v', axis = "rl") + theme_map()
   )
 })
+
+
+test_that("align by axis", {
+  p1 <- ggplot(mtcars, aes(x = disp, y = mpg)) +
+    geom_point()
+  p2 <- ggplot(mtcars[mtcars$disp > 300, ], aes(x = disp, y = mpg)) +
+    geom_point()
+
+  expect_doppelganger("aligning by x-axis values",
+    plot_grid(p1, p2, ncol = 1, align = "v",  align_axis = TRUE)
+  )
+
+  p3 <- ggplot(mtcars[mtcars$mpg > 20, ], aes(x = disp, y = mpg)) +
+    geom_point()
+
+  expect_doppelganger("aligning by y-axis values",
+    plot_grid(p1, p3, nrow = 1, align = "h",  align_axis = TRUE)
+  )
+})


### PR DESCRIPTION
This PR adds functionality that allows the user to align plots by axis values, effectively closing #173.

Note that this is using the code by [Z.lin](https://stackoverflow.com/users/8449629/z-lin) as proposed [here on SO](https://stackoverflow.com/a/57575725/3048453).

Both `align_plots` and `plot_grid` gain a new flag `align_axis = FALSE`. If set to TRUE, the graphs are aligned by their axis values as well.

First a quick showcase:

```
library(ggplot2)

p1 <- ggplot(mtcars, aes(x = disp, y = mpg)) + geom_point()

# Vertical Align (by X axis)
p2 <- ggplot(mtcars[mtcars$disp > 300, ], aes(x = disp, y = mpg)) + geom_point()
plot_grid(p1, p2, ncol = 1, align = "v",  align_axis = TRUE)
```
![image](https://user-images.githubusercontent.com/15910496/225966937-98712de7-a5ea-402c-9644-5b7d0b1b6061.png)


```
# Horizontal Align (by Y axis)
p3 <- ggplot(mtcars[mtcars$mpg > 20, ], aes(x = disp, y = mpg)) + geom_point()
plot_grid(p1, p3, nrow = 1, align = "h",  align_axis = TRUE)
```
![image](https://user-images.githubusercontent.com/15910496/225967019-1110f19e-8587-45cb-8001-4920d90d657a.png)


There are some tests added as well, but especially the tests for `align_plots()` are very crude/early as I don't have enough experience with the internals of units and there are some minor differences in some elements of the units. So far I captured the printed output, which is identical. We probably want to update that.

Let me know if there are tests missing and if so which ones. Also feel free to add to this.
