### PR TITLE
Update for ggplot2 3.5.0

### DIFF
--- a/R/align_plots.R
+++ b/R/align_plots.R
@@ -53,7 +53,7 @@ align_margin <- function(sizes, margin_to_align, greedy = TRUE) {
       sizes,
       function(x) {
         # find all positions of unit NULL
-        null_idx <- grep("null", x)
+        null_idx <- grep("null$", x)
         # if there are none, abort
         if (length(null_idx) < 1) {
           return(NULL)
@@ -70,7 +70,7 @@ align_margin <- function(sizes, margin_to_align, greedy = TRUE) {
       sizes,
       function(x) {
         # find all positions of unit NULL
-        null_idx <- grep("null", x)
+        null_idx <- grep("null$", x)
         # if there are none, abort
         if (length(null_idx) < 1) {
           return(NULL)

--- a/tests/testthat/test_align_plots.R
+++ b/tests/testthat/test_align_plots.R
@@ -45,8 +45,8 @@ test_that("complex alignments, h, v, hv", {
   expect_equal(plots[[1]]$widths[1:4], plots[[2]]$widths[1:4])
 
   plots <- align_plots(p1, p2, align = "v", axis = "r", greedy = FALSE)  # align right
-  ncol <- vapply(plots, ncol, integer(1))
-  expect_equal(plots[[1]]$widths[ncol[1] - 3:0], plots[[2]]$widths[ncol[2] - 3:0])
+  n <- vapply(plots, ncol, integer(1))
+  expect_equal(plots[[1]]$widths[n[1] - 3:0], plots[[2]]$widths[n[2] - 3:0])
 
   # with greedy = TRUE, only the sums of the widths are equal
   plots <- align_plots(p1, p2, align = "v", axis = "l", greedy = TRUE)   # align left
@@ -56,10 +56,10 @@ test_that("complex alignments, h, v, hv", {
   )
 
   plots <- align_plots(p1, p2, align = "v", axis = "r", greedy = TRUE)   # align right
-  ncol <- vapply(plots, ncol, integer(1))
+  n <- vapply(plots, ncol, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 3:0]), "in"),
-    grid::convertUnit(sum(plots[[2]]$widths[ncol[2] - 3:0]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[n[1] - 3:0]), "in"),
+    grid::convertUnit(sum(plots[[2]]$widths[n[2] - 3:0]), "in")
   )
 
 
@@ -70,9 +70,9 @@ test_that("complex alignments, h, v, hv", {
   expect_warning(align_plots(p1, p3, align = "h"))
 
   plots <- align_plots(p1, p3, align = "h", axis = "bt", greedy = FALSE)
-  nrow <- vapply(plots, nrow, integer(1))
+  n <- vapply(plots, nrow, integer(1))
   expect_equal(
-    grid::convertUnit(plots[[1]]$heights[nrow[1] - 3:0] - plots[[2]]$heights[nrow[2] - 3:0], "cm"),
+    grid::convertUnit(plots[[1]]$heights[n[1] - 3:0] - plots[[2]]$heights[n[2] - 3:0], "cm"),
     grid::unit(c(0, 0, 0, 0), "cm")
   )
 
@@ -110,16 +110,16 @@ test_that("complex alignments with non-plots", {
 
   # because p1 has a legend and p2 doesn't, only the sums of the widths are equal for right align
   plots <- align_plots(p1, p2, p3, align = "v", axis = "r", greedy = FALSE)  # align right
-  ncol <- vapply(plots, ncol, integer(1))
+  n <- vapply(plots, ncol, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 5:0]), "in"),
-    grid::convertUnit(sum(plots[[2]]$widths[ncol[2] - 3:0]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[n[1] - 5:0]), "in"),
+    grid::convertUnit(sum(plots[[2]]$widths[n[2] - 3:0]), "in")
   )
   plots <- align_plots(p1, NULL, p2, p3, align = "v", axis = "r", greedy = FALSE)  # align right
-  ncol <- vapply(plots, NCOL, integer(1))
+  n <- vapply(plots, NCOL, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 5:0]), "in"),
-    grid::convertUnit(sum(plots[[3]]$widths[ncol[3] - 3:0]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[n[1] - 5:0]), "in"),
+    grid::convertUnit(sum(plots[[3]]$widths[n[3] - 3:0]), "in")
   )
 
   # with greedy = TRUE, only the sums of the widths are equal
@@ -135,16 +135,16 @@ test_that("complex alignments with non-plots", {
   )
 
   plots <- align_plots(p1, p2, p3, align = "v", axis = "r", greedy = TRUE)   # align right
-  ncol <- vapply(plots, ncol, integer(1))
+  n <- vapply(plots, ncol, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 5:0]), "in"),
-    grid::convertUnit(sum(plots[[2]]$widths[ncol[2] - 3:0]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[n[1] - 5:0]), "in"),
+    grid::convertUnit(sum(plots[[2]]$widths[n[2] - 3:0]), "in")
   )
   plots <- align_plots(p1, NULL, p2, align = "v", axis = "r", greedy = TRUE)   # align right
-  ncol <- vapply(plots, NCOL, integer(1))
+  n <- vapply(plots, NCOL, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 5:0]), "in"),
-    grid::convertUnit(sum(plots[[3]]$widths[ncol[3] - 3:0]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[n[1] - 5:0]), "in"),
+    grid::convertUnit(sum(plots[[3]]$widths[n[3] - 3:0]), "in")
   )
 
   dev.off()

--- a/tests/testthat/test_align_plots.R
+++ b/tests/testthat/test_align_plots.R
@@ -45,7 +45,8 @@ test_that("complex alignments, h, v, hv", {
   expect_equal(plots[[1]]$widths[1:4], plots[[2]]$widths[1:4])
 
   plots <- align_plots(p1, p2, align = "v", axis = "r", greedy = FALSE)  # align right
-  expect_equal(plots[[1]]$widths[6:9], plots[[2]]$widths[14:17])
+  ncol <- vapply(plots, ncol, integer(1))
+  expect_equal(plots[[1]]$widths[ncol[1] - 3:0], plots[[2]]$widths[ncol[2] - 3:0])
 
   # with greedy = TRUE, only the sums of the widths are equal
   plots <- align_plots(p1, p2, align = "v", axis = "l", greedy = TRUE)   # align left
@@ -55,9 +56,10 @@ test_that("complex alignments, h, v, hv", {
   )
 
   plots <- align_plots(p1, p2, align = "v", axis = "r", greedy = TRUE)   # align right
+  ncol <- vapply(plots, ncol, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[6:9]), "in"),
-    grid::convertUnit(sum(plots[[2]]$widths[14:17]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 3:0]), "in"),
+    grid::convertUnit(sum(plots[[2]]$widths[ncol[2] - 3:0]), "in")
   )
 
 
@@ -68,15 +70,17 @@ test_that("complex alignments, h, v, hv", {
   expect_warning(align_plots(p1, p3, align = "h"))
 
   plots <- align_plots(p1, p3, align = "h", axis = "bt", greedy = FALSE)
+  nrow <- vapply(plots, nrow, integer(1))
   expect_equal(
-    grid::convertUnit(plots[[1]]$heights[7:10] - plots[[2]]$heights[18:21], "cm"),
+    grid::convertUnit(plots[[1]]$heights[nrow[1] - 3:0] - plots[[2]]$heights[nrow[2] - 3:0], "cm"),
     grid::unit(c(0, 0, 0, 0), "cm")
   )
 
   # these units are only equal after we've added everything up
+  rows <- c(panel_rows(plots[[1]])$t[1], panel_rows(plots[[2]])$t[1]) - 1
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$heights[1:6]), "cm"),
-    grid::convertUnit(sum(plots[[2]]$heights[1:7]), "cm")
+    grid::convertUnit(sum(plots[[1]]$heights[1:rows[1]]), "cm"),
+    grid::convertUnit(sum(plots[[2]]$heights[1:rows[2]]), "cm")
   )
   dev.off()
 })
@@ -106,14 +110,16 @@ test_that("complex alignments with non-plots", {
 
   # because p1 has a legend and p2 doesn't, only the sums of the widths are equal for right align
   plots <- align_plots(p1, p2, p3, align = "v", axis = "r", greedy = FALSE)  # align right
+  ncol <- vapply(plots, ncol, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[6:11]), "in"),
-    grid::convertUnit(sum(plots[[2]]$widths[14:17]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 5:0]), "in"),
+    grid::convertUnit(sum(plots[[2]]$widths[ncol[2] - 3:0]), "in")
   )
   plots <- align_plots(p1, NULL, p2, p3, align = "v", axis = "r", greedy = FALSE)  # align right
+  ncol <- vapply(plots, NCOL, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[6:11]), "in"),
-    grid::convertUnit(sum(plots[[3]]$widths[14:17]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 5:0]), "in"),
+    grid::convertUnit(sum(plots[[3]]$widths[ncol[3] - 3:0]), "in")
   )
 
   # with greedy = TRUE, only the sums of the widths are equal
@@ -129,14 +135,16 @@ test_that("complex alignments with non-plots", {
   )
 
   plots <- align_plots(p1, p2, p3, align = "v", axis = "r", greedy = TRUE)   # align right
+  ncol <- vapply(plots, ncol, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[6:11]), "in"),
-    grid::convertUnit(sum(plots[[2]]$widths[14:17]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 5:0]), "in"),
+    grid::convertUnit(sum(plots[[2]]$widths[ncol[2] - 3:0]), "in")
   )
   plots <- align_plots(p1, NULL, p2, align = "v", axis = "r", greedy = TRUE)   # align right
+  ncol <- vapply(plots, NCOL, integer(1))
   expect_equal(
-    grid::convertUnit(sum(plots[[1]]$widths[6:11]), "in"),
-    grid::convertUnit(sum(plots[[3]]$widths[14:17]), "in")
+    grid::convertUnit(sum(plots[[1]]$widths[ncol[1] - 5:0]), "in"),
+    grid::convertUnit(sum(plots[[3]]$widths[ncol[3] - 3:0]), "in")
   )
 
   dev.off()

--- a/tests/testthat/test_get_legend.R
+++ b/tests/testthat/test_get_legend.R
@@ -10,6 +10,6 @@ test_that("get legend", {
   expect_equal(l$name, "guide-box")
 
   # return null legend if no legend
-  expect_null(get_legend(p + theme(legend.position = "none")))
+  expect_s3_class(get_legend(p + theme(legend.position = "none")), "zeroGrob")
 })
 

--- a/tests/testthat/test_get_legend.R
+++ b/tests/testthat/test_get_legend.R
@@ -10,6 +10,14 @@ test_that("get legend", {
   expect_equal(l$name, "guide-box")
 
   # return null legend if no legend
-  expect_s3_class(get_legend(p + theme(legend.position = "none")), "zeroGrob")
+  # Note by Teun: It is yet unclear to me what the desired behaviour of
+  # `get_legend()` is in the face of multiple legends.
+  # For now, this test is conditional on ggplot2 version, but this is
+  # more of a duct tape solution than a reflection of the intended behaviour
+  if (utils::packageVersion("ggplot2") >= "3.5.0") {
+    expect_s3_class(get_legend(p + theme(legend.position = "none")), "zeroGrob")
+  } else {
+    expect_null(get_legend(p + theme(legend.position = "none")))
+  }
 })
 

--- a/tests/testthat/test_plot_components.R
+++ b/tests/testthat/test_plot_components.R
@@ -9,6 +9,13 @@ test_that("plot components", {
     "axis-b", "spacer", "axis-r", "spacer", "xlab-t", "xlab-b", "ylab-l",
     "ylab-r", "guide-box", "subtitle", "title", "caption", "tag"
   )
+  if (inherits(guide_legend(), "Guide")) { # proxy testing for ggplot2 3.5.0+
+    component_names <- setdiff(component_names, c("guide-box", "tag"))
+    component_names <- union(
+      component_names,
+      paste0("guide-box-", c("left", "right", "top", "bottom", "inside"))
+    )
+  }
 
   expect_type(plot_component_names(p), "character")
   expect_true(all(component_names %in% plot_component_names(p)))


### PR DESCRIPTION
Hi Claus,

As you might have noticed, we have been preparing a new release of ggplot2. During a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break cowplot.

This PR updates cowplot to work with the new ggplot2 version. It does the following things:

* `align_margins()` is updated to find only simple 'null'-units. The guide-boxes might contain compound 'null'-units and shouldn't be considered the same as panels.
* Updates alignment tests consider right/bottom alignment based on the number of columns/rows instead of absolute indices.
* Updated a few other tests whose assumptions no longer hold.

What you still might consider but isn't currently breaking, is how `get_legend()` should handle multiple guide positions introduced by https://github.com/tidyverse/ggplot2/pull/5488.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. I hope that this PR might help cowplot get out a fix if necessary.